### PR TITLE
Add gpg2 support and other refactors.

### DIFF
--- a/lib/facter/gpg_info.rb
+++ b/lib/facter/gpg_info.rb
@@ -12,14 +12,15 @@ Facter.add(:gpg_info) do
     gpg_path = Facter.value(:gpg_path)
     if gpg_path
       gpg_info['path'] = gpg_path
-      output = Facter::Core::Execution.execute("#{gpg_path} --version")
-      output.split("\n").each do |line|
-        if line =~ %r{^gpg \(GnuPG\) (\d.*)$}
-          gpg_info['version'] = Regexp.last_match(1)
-          next
-        elsif line =~ %r{^libgcrypt (\d.*)$}
-          gpg_info['libgcrypt'] = Regexp.last_match(1)
-          next
+      IO.popen([gpg_path, '--version'], err: [:child, :out]) do |output|
+        output.readlines.each do |line|
+          if line =~ %r{^gpg \(GnuPG\) (\d.*)$}
+            gpg_info['version'] = Regexp.last_match(1)
+            next
+          elsif line =~ %r{^libgcrypt (\d.*)$}
+            gpg_info['libgcrypt'] = Regexp.last_match(1)
+            next
+          end
         end
       end
     end

--- a/lib/facter/gpg_keys.rb
+++ b/lib/facter/gpg_keys.rb
@@ -1,7 +1,8 @@
-# rubocop:disable Metrics/BlockLength
+require File.expand_path('../../puppet_x/keypair/gpg', __FILE__)
+
 Facter.add(:gpg_keys) do
   setcode do
-    dir = '/etc/gpg_keys'
+    dir = PuppetX::Keypair::GPG.keydir
 
     keys = {}
     begin

--- a/lib/facter/gpg_keys.rb
+++ b/lib/facter/gpg_keys.rb
@@ -12,7 +12,7 @@ Facter.add(:gpg_keys) do
           basename = Regexp.last_match(1)
 
           keys[basename] = { 'basename' => basename } unless keys[basename]
-
+          keys[basename]['keydir'] = dir
           keys[basename]['public_present'] = true if Regexp.last_match(2) == 'pub'
           keys[basename]['secret_present'] = true if Regexp.last_match(2) == 'sec'
 

--- a/lib/puppet/functions/keypair/gpg_keydir.rb
+++ b/lib/puppet/functions/keypair/gpg_keydir.rb
@@ -1,0 +1,11 @@
+require File.expand_path('../../../../puppet_x/keypair/gpg', __FILE__)
+
+Puppet::Functions.create_function(:'keypair::gpg_keydir') do
+  # Returns the gpg keydir used in this module.
+  dispatch :gpg_keydir do
+  end
+
+  def gpg_keydir
+    PuppetX::Keypair::GPG.keydir
+  end
+end

--- a/lib/puppet_x/keypair/gpg.rb
+++ b/lib/puppet_x/keypair/gpg.rb
@@ -9,6 +9,41 @@ module PuppetX
       def self.keydir
         '/etc/gpg_keys'
       end
+
+      # Parse a IO stream (IO.popen) and extract (gpg) key information.
+      # You should use the folling gpg options to get a parseable result:
+      # `gpg --list-keys --with-fingerprint --with-colon --fixed-list-mode`
+      def self.parse_gpg_io(io)
+        keys = []
+        current = {}
+        io.readlines.each do |line|
+          if line =~ %r{^pub:[^:]*:(\d+):(\d+):([0-9a-fA-F]+):[^:]*:[^:]*:[^:]*:[^:]*:([^:]*):}
+            # check if we are starting a new key.
+            if current['keyid'] && current['keyid'] != Regexp.last_match(3)
+              keys << current
+              current = {}
+            end
+            current['key_length'] = Regexp.last_match(1).to_i
+            current['algo'] = Regexp.last_match(2).to_i
+            current['keyid'] = Regexp.last_match(3)
+            unless Regexp.last_match(4).empty?
+              current['uid'] = Regexp.last_match(4).clone.gsub(%r{((?:\\[0-9a-fA-F]{2})+)}) { |m|
+                [m.delete('\\')].pack('H*')
+              }.force_encoding('UTF-8')
+            end
+          elsif line =~ %r{^fpr:::::::::([0-9a-fA-F]+)}
+            current['fingerprint'] = Regexp.last_match(1)
+          elsif line =~ %r{^uid:[^:]*:[^:]*:[^:]*:[^:]*:[^:]*:[^:]*:[^:]*:[^:]*:([^:]*):}
+            current['uid'] = Regexp.last_match(1).clone.gsub(%r{((?:\\[0-9a-fA-F]{2})+)}) { |m|
+              [m.delete('\\')].pack('H*')
+            }.force_encoding('UTF-8')
+          end
+        end
+        if current['keyid']
+          keys << current
+        end
+        keys
+      end
     end
   end
 end

--- a/lib/puppet_x/keypair/gpg.rb
+++ b/lib/puppet_x/keypair/gpg.rb
@@ -1,0 +1,14 @@
+# rubocop:disable Style/ClassAndModuleChildren :
+# rubocop wants us to use `class PuppetX::Keypair::GPG` which we can't
+# since the parent modules `PuppetX` and `PuppetX::Keypair` do not exist yet.
+module PuppetX
+  # Extra keypair libs
+  module Keypair
+    # GPG helpers.
+    module GPG
+      def self.keydir
+        '/etc/gpg_keys'
+      end
+    end
+  end
+end

--- a/lib/puppet_x/keypair/gpg.rb
+++ b/lib/puppet_x/keypair/gpg.rb
@@ -17,7 +17,7 @@ module PuppetX
         keys = []
         current = {}
         io.readlines.each do |line|
-          if line =~ %r{^pub:[^:]*:(\d+):(\d+):([0-9a-fA-F]+):[^:]*:[^:]*:[^:]*:[^:]*:([^:]*):}
+          if line =~ %r{^pub:[^:]*:(\d+):(\d+):([0-9a-fA-F]+):(?:[^:]*:)+([^:]*):}
             # check if we are starting a new key.
             if current['keyid'] && current['keyid'] != Regexp.last_match(3)
               keys << current

--- a/manifests/gpg.pp
+++ b/manifests/gpg.pp
@@ -5,7 +5,8 @@ class keypair::gpg (
   Boolean $manage_dir = true,
 ) {
   if $manage_dir {
-    file { '/etc/gpg_keys':
+    $keydir = keypair::gpg_keydir()
+    file { $keydir:
       ensure => directory,
       mode   => '0755',
       owner  => 'root',

--- a/manifests/gpg_keypair.pp
+++ b/manifests/gpg_keypair.pp
@@ -12,14 +12,16 @@ define keypair::gpg_keypair (
   $uid = nil,
 ) {
 
-  include gpg # To make the parent directory
+  include keypair::gpg # To make the parent directory
+
+  $keydir = keypair::gpg_keydir()
 
   $existing_key = keypair::get_first_matching_value($::gpg_keys, {
       'secret_present' => true,
       'basename'       => $basename,
     })
 
-  $filename = "/etc/gpg_keys/${basename}"
+  $filename = "${keydir}/${basename}"
 
   if $existing_key {
     $key = $existing_key

--- a/spec/classes/keypair__gpg_spec.rb
+++ b/spec/classes/keypair__gpg_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe 'keypair::gpg' do
+  let(:pre_condition) do
+    <<-puppet
+    function keypair::gpg_keydir() {
+      '/etc/puppet_keypairs'
+    }
+    puppet
+  end
+
+  context 'manage => true' do
+    let(:params) { { manage_dir: true } }
+
+    it { is_expected.to compile }
+    it do
+      is_expected.to contain_file('/etc/puppet_keypairs')
+    end
+  end
+
+  context 'manage => false' do
+    let(:params) { { manage_dir: false } }
+
+    it { is_expected.to compile }
+    it do
+      is_expected.not_to contain_file('/etc/puppet_keypairs')
+    end
+  end
+end

--- a/spec/defines/keypair__gpg_keypair_spec.rb
+++ b/spec/defines/keypair__gpg_keypair_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe 'keypair::gpg_keypair' do
+  let(:title) { 'mykey' }
+  let(:params) { { basename: 'mykey', uid: 'My UID' } }
+  let(:keydir) { '/etc/puppet_keypair' }
+
+  context 'new key' do
+    let(:pre_condition) do
+      <<-puppet
+      function keypair::gpg_keydir() {
+        "#{keydir}"
+      }
+      function gpg_generate_key(Hash $opts) {
+        $opts + {
+          'secret_key' => 'very secret',
+          'public_key' => 'public',
+        }
+      }
+    puppet
+    end
+
+    let(:facts) do
+      { gpg_keys: {} }
+    end
+
+    it { is_expected.to compile }
+    it { is_expected.to contain_class('keypair::gpg') }
+    it { is_expected.to contain_file("#{keydir}/mykey.sec").with_content('very secret') }
+    it { is_expected.to contain_file("#{keydir}/mykey.pub").with_content('public') }
+  end
+
+  context 'key already exists' do
+    let(:pre_condition) do
+      <<-puppet
+      function keypair::gpg_keydir() {
+        "#{keydir}"
+      }
+      function gpg_generate_key(Hash $opts) {
+        fail('if the key exists, we should never be here')
+      }
+      puppet
+    end
+    let(:facts) do
+      {
+        gpg_keys: {
+          'mykey' => {
+            'basename'       => 'mykey',
+            'secret_present' => true,
+            'public_key'     => 'public exists',
+          },
+        },
+      }
+    end
+
+    it { is_expected.to compile }
+    it { is_expected.to contain_class('keypair::gpg') }
+    it { is_expected.to contain_file("#{keydir}/mykey.sec").with_ensure('file').with_content(nil) }
+    it { is_expected.to contain_file("#{keydir}/mykey.pub").with_ensure('file').with_content('public exists') }
+  end
+end

--- a/spec/functions/get_first_matching_value_spec.rb
+++ b/spec/functions/get_first_matching_value_spec.rb
@@ -30,7 +30,7 @@ describe 'keypair::get_first_matching_value' do
   context 'strict is false' do
     it 'does return first element when no criteria is set' do
       is_expected.to run.with_params(
-        { 'a' => { 'check' => 'mark' }, 'b' => {} }.freeze
+        { 'a' => { 'check' => 'mark' }, 'b' => {} }.freeze,
       ).and_return('check' => 'mark')
     end
 
@@ -38,21 +38,21 @@ describe 'keypair::get_first_matching_value' do
       is_expected.to run.with_params(
         { 'a' => { 'check' => 'mark' }, 'b' => {} }.freeze,
         nil,
-        false
+        false,
       ).and_return('check' => 'mark')
     end
 
     it 'does return what matches' do
       is_expected.to run.with_params(
         { 'a' => { 'check' => 'mark' }, 'b' => { 'check' => 'this' } }.freeze,
-        'check' => 'this'
+        'check' => 'this',
       ).and_return('check' => 'this')
     end
 
     it 'returns nil if there are no matches' do
       is_expected.to run.with_params(
         { 'a' => { 'check' => 'mark' }, 'b' => { 'check' => 'this' } }.freeze,
-        'foo' => 'bar'
+        'foo' => 'bar',
       ).and_return(nil)
     end
   end
@@ -62,7 +62,7 @@ describe 'keypair::get_first_matching_value' do
       is_expected.to run.with_params(
         { 'a' => { 'check' => 'mark' }, 'b' => {} }.freeze,
         nil,
-        true
+        true,
       ).and_return(nil)
     end
 
@@ -70,14 +70,14 @@ describe 'keypair::get_first_matching_value' do
       is_expected.to run.with_params(
         { 'a' => { 'check' => 'mark', 'must' => 'match' }, 'b' => { 'check' => 'this', 'must' => 'match', 'extra' => 'stuff' } }.freeze,
         { 'check' => 'this', 'must' => 'match' },
-        true
+        true,
       ).and_return('check' => 'this', 'must' => 'match', 'extra' => 'stuff')
     end
     it 'returns nil if there are no matches' do
       is_expected.to run.with_params(
         { 'a' => { 'check' => 'mark' }, 'b' => { 'check' => 'this' } }.freeze,
         { 'foo' => 'bar' },
-        true
+        true,
       ).and_return(nil)
     end
   end

--- a/spec/functions/keypair/gpg_keydir_spec.rb
+++ b/spec/functions/keypair/gpg_keydir_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'keypair::gpg_keydir' do
+  it 'exists' do
+    is_expected.not_to be_nil
+  end
+
+  describe 'returns the gpg dir from PuppetX::Keypair::GPG' do
+    before(:each) do
+      allow(PuppetX::Keypair::GPG).to receive(:keydir).and_return('/etc/puppet_keypairs')
+    end
+
+    it do
+      is_expected.to run.and_return('/etc/puppet_keypairs')
+    end
+  end
+end

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -1,4 +1,5 @@
 # put local configuration and setup here
+require 'puppet_x/keypair/gpg'
 
 class String
   def unindent

--- a/spec/unit/puppet_x/keypair/gpg_spec.rb
+++ b/spec/unit/puppet_x/keypair/gpg_spec.rb
@@ -1,0 +1,120 @@
+require 'spec_helper'
+
+require 'puppet_x/keypair/gpg'
+
+describe PuppetX::Keypair::GPG do
+  describe 'no keys' do
+    let(:output) { '' }
+
+    it do
+      io = instance_double('IO')
+      allow(io).to receive(:readlines) { output.split("\n") }
+
+      expect(described_class.parse_gpg_io(io)).to eq([])
+    end
+  end
+
+  describe 'parse a single key (gpg1)' do
+    let(:output) do
+      <<-OUTPUT.unindent
+        pub:-:2048:1:51A967C4EA88C58F:1569404883:::-:Aptly repo server signing key:
+        fpr:::::::::644C1EF3F0B831DDCE9EBD3D51A967C4EA88C58F:
+      OUTPUT
+    end
+    let(:parsed) do
+      [{
+        'algo' => 1,
+        'fingerprint' => '644C1EF3F0B831DDCE9EBD3D51A967C4EA88C58F',
+        'key_length'  => 2048,
+        'keyid'       => '51A967C4EA88C58F',
+        'uid'         => 'Aptly repo server signing key',
+      }]
+    end
+
+    it 'returns a single key' do
+      io = instance_double('IO')
+      allow(io).to receive(:readlines) { output.split("\n") }
+
+      expect(described_class.parse_gpg_io(io)).to eq(parsed)
+    end
+  end
+
+  describe 'parse a single key (gpg2)' do
+    let(:output) do
+      <<-OUTPUT.unindent
+        gpg: WARNING: unsafe permissions on homedir '/tmp/spec/fixtures/certificates'
+        tru::1:1569258565:0:3:1:5
+        pub:u:1024:1:CBD11408E914BAD1:1569258537:::u:::scSC::::::::0:
+        fpr:::::::::2CF27DBD938AF18934A3E888CBD11408E914BAD1:
+        uid:u::::1569258537::46E113E588AC5287649ACD886BAFDB7310B5E2EA::My key name YAY\\x3a testing::::::::::0:
+      OUTPUT
+    end
+
+    let(:parsed) do
+      [{
+        'algo' => 1,
+        'fingerprint' => '2CF27DBD938AF18934A3E888CBD11408E914BAD1',
+        'key_length' => 1024,
+        'keyid' => 'CBD11408E914BAD1',
+        'uid' => 'My key name YAY\\x3a testing',
+      }]
+    end
+
+    it 'returns a single key' do
+      io = instance_double('IO')
+      allow(io).to receive(:readlines) { output.split("\n") }
+
+      expect(described_class.parse_gpg_io(io)).to eq(parsed)
+    end
+  end
+
+  describe 'parse multiple key (gpg2)' do
+    let(:output) do
+      <<-OUTPUT.unindent
+        gpg: WARNING: unsafe permissions on homedir '/tmp/spec/fixtures/certificates'
+        gpg: checking the trustdb
+        gpg: marginals needed: 3  completes needed: 1  trust model: pgp
+        gpg: depth: 0  valid:   2  signed:   0  trust: 0-, 0q, 0n, 0m, 0f, 2u
+        tru:o:1:1569258565:1:3:1:5
+        pub:u:1024:1:CBD11408E914BAD1:1569258537:::u:::scSC::::::::0:
+        fpr:::::::::2CF27DBD938AF18934A3E888CBD11408E914BAD1:
+        uid:u::::1569258537::46E113E588AC5287649ACD886BAFDB7310B5E2EA::My key name YAY\\x3a testing::::::::::0:
+        pub:u:1024:1:59DD5930D536F772:1569259166:::u:::scSC::::::::0:
+        fpr:::::::::0B70FB6322D4C0BFF068AD5E59DD5930D536F772:
+        uid:u::::1569259166::DF02BBF23C0FC1205AEE9040933A64B3B2C12B28::Deal with more than one too::::::::::0:
+      OUTPUT
+    end
+
+    let(:parsed) do
+      [{
+        'algo' => 1,
+        'fingerprint' => '2CF27DBD938AF18934A3E888CBD11408E914BAD1',
+        'key_length' => 1024,
+        'keyid' => 'CBD11408E914BAD1',
+        'uid' => 'My key name YAY\\x3a testing',
+      },
+       {
+         'algo' => 1,
+         'fingerprint' => '0B70FB6322D4C0BFF068AD5E59DD5930D536F772',
+         'key_length' => 1024,
+         'keyid' => '59DD5930D536F772',
+         'uid' => 'Deal with more than one too',
+       }]
+    end
+
+    it 'returns multiple keys' do
+      io = instance_double('IO')
+      allow(io).to receive(:readlines) { output.split("\n") }
+      expect(described_class.parse_gpg_io(io)).to eq(parsed)
+    end
+
+    # This code was used to populate the test data and is kept here for reference purposes.
+    #
+    # it 'should work for real' do
+    #   IO.popen(['gpg', '--homedir', 'spec/fixtures/certificates', '--list-keys',
+    #           '--with-fingerprint', '--with-colons', '--fixed-list-mode']) do |io|
+    #     expect(PuppetX::Keypair::GPG.parse_gpg_io(io)).to eq(parsed)
+    #   end
+    # end
+  end
+end

--- a/spec/unit/puppet_x/keypair/gpg_spec.rb
+++ b/spec/unit/puppet_x/keypair/gpg_spec.rb
@@ -14,7 +14,7 @@ describe PuppetX::Keypair::GPG do
     end
   end
 
-  describe 'parse a single key (gpg1)' do
+  describe 'a single key in a file (gpg1)' do
     let(:output) do
       <<-OUTPUT.unindent
         pub:-:2048:1:51A967C4EA88C58F:1569404883:::-:Aptly repo server signing key:
@@ -39,7 +39,34 @@ describe PuppetX::Keypair::GPG do
     end
   end
 
-  describe 'parse a single key (gpg2)' do
+  describe 'single key in a file (gpg2)' do
+    let(:output) do
+      <<-OUTPUT.unindent
+        gpg: WARNING: no command supplied.  Trying to guess what you mean ...
+        pub:-:2048:1:E57A76F96110C25F:1569249893:::-:
+        fpr:::::::::4112E0391394060387E5698DE57A76F96110C25F:
+        uid:::::::::Aptly repository signing key:
+      OUTPUT
+    end
+    let(:parsed) do
+      [{
+        'algo' => 1,
+        'key_length' => 2048,
+        'keyid' => 'E57A76F96110C25F',
+        'uid' => 'Aptly repository signing key',
+        'fingerprint' => '4112E0391394060387E5698DE57A76F96110C25F',
+      }]
+    end
+
+    it 'returns a single key' do
+      io = instance_double('IO')
+      allow(io).to receive(:readlines) { output.split("\n") }
+
+      expect(described_class.parse_gpg_io(io)).to eq(parsed)
+    end
+  end
+
+  describe 'single key in a keyring (gpg2)' do
     let(:output) do
       <<-OUTPUT.unindent
         gpg: WARNING: unsafe permissions on homedir '/tmp/spec/fixtures/certificates'
@@ -68,7 +95,7 @@ describe PuppetX::Keypair::GPG do
     end
   end
 
-  describe 'parse multiple key (gpg2)' do
+  describe 'multiple keys in a keyring (gpg2)' do
     let(:output) do
       <<-OUTPUT.unindent
         gpg: WARNING: unsafe permissions on homedir '/tmp/spec/fixtures/certificates'


### PR DESCRIPTION
* Use the same method for all IO calls to gpg to retrieve information
* Centralize gpg output parsing
* Define the used keydir (/etc/gpg_keys) in one place in this repository